### PR TITLE
Fix frontend match descriptors and API base URL

### DIFF
--- a/frontend/dart-scoring-frontend/src/App.vue
+++ b/frontend/dart-scoring-frontend/src/App.vue
@@ -15,7 +15,12 @@ const matchDescriptor = computed(() => {
     return null;
   }
 
-  const playerNames = activeMatch.value.players.map(player => player.displayName).join(' vs ');
+  const players = Array.isArray(activeMatch.value.players) ? activeMatch.value.players : [];
+  if (players.length === 0) {
+    return `${activeMatch.value.mode}`;
+  }
+
+  const playerNames = players.map(player => player.displayName).join(' vs ');
   return `${activeMatch.value.mode} • ${playerNames}`;
 });
 

--- a/frontend/dart-scoring-frontend/src/pages/NewMatchPage.vue
+++ b/frontend/dart-scoring-frontend/src/pages/NewMatchPage.vue
@@ -34,6 +34,19 @@ const canCreate = computed(
 );
 
 const availablePlayers = computed(() => players.value);
+const resumeMatchDescriptor = computed(() => {
+  if (!activeMatch.value) {
+    return '';
+  }
+
+  const matchPlayers = Array.isArray(activeMatch.value.players) ? activeMatch.value.players : [];
+  if (matchPlayers.length === 0) {
+    return `${activeMatch.value.mode}`;
+  }
+
+  const playerNames = matchPlayers.map(player => player.displayName).join(' vs ');
+  return `${activeMatch.value.mode} • ${playerNames}`;
+});
 
 onMounted(() => {
   matchStore.fetchPlayers();
@@ -212,9 +225,8 @@ async function loadDemoMatch(matchId: number) {
 
         <div v-if="activeMatch" class="resume">
           <h3>Resume current match</h3>
-          <p>
-            {{ activeMatch.mode }} •
-            {{ activeMatch.players.map(player => player.displayName).join(' vs ') }}
+          <p v-if="resumeMatchDescriptor">
+            {{ resumeMatchDescriptor }}
           </p>
           <div class="resume__actions">
             <button

--- a/infrastructure/docker-compose.yml
+++ b/infrastructure/docker-compose.yml
@@ -36,7 +36,7 @@ services:
       context: ../frontend/dart-scoring-frontend
       dockerfile: Dockerfile
       args:
-        VITE_API_BASE_URL: ${DOCKER_VITE_API_BASE_URL:-http://api:5200}
+        VITE_API_BASE_URL: ${DOCKER_VITE_API_BASE_URL:-http://localhost:5200}
     container_name: darts-web
     depends_on:
       api:


### PR DESCRIPTION
## Summary
- guard match descriptor logic to avoid crashes when the active match payload is missing its players array
- reuse a safe computed descriptor on the new match page so the resume card renders without errors
- default the Docker Compose web build to a localhost API URL that works from the browser

## Testing
- npm run test -- --run

------
https://chatgpt.com/codex/tasks/task_e_68cc539769a88320ab8a9a6ccbe77ef3